### PR TITLE
Fix installation error in installDuti function

### DIFF
--- a/util/install.go
+++ b/util/install.go
@@ -33,19 +33,20 @@ func installDuti() {
 	if !commandExists("duti") {
 		fmt.Println("Duti not exists, installing ...")
 		cmd := exec.Command("brew", "install", "duti")
-		_, err := cmd.Output()
+		output, err := cmd.CombinedOutput()
 		if err != nil {
-			fmt.Println(string(err.(*exec.ExitError).Stderr))
-			panic(err)
+			fmt.Println(string(output))
+			fmt.Println("Error installing duti:", err)
+			return
 		}
 	}
 
 	cmd := exec.Command("man", "duti")
-	_, err := cmd.Output()
-
+	output, err := cmd.CombinedOutput()
 	if err != nil {
-		fmt.Println(string(err.(*exec.ExitError).Stderr))
-		panic(err)
+		fmt.Println(string(output))
+		fmt.Println("Error checking duti installation:", err)
+		return
 	} else {
 		fmt.Println("Duti works fine")
 	}


### PR DESCRIPTION
Fix the installation of the brew formula on macOS by handling errors correctly in the `installDuti` function.

* Use `cmd.CombinedOutput()` instead of `cmd.Output()` in the `installDuti` function to capture both stdout and stderr.
* Improve error handling in the `installDuti` function to print the error message and exit gracefully instead of panicking.