### PR TITLE
Add GitHub release with binary linked

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,6 @@ jobs:
         with:
           distribution: goreleaser
           version: '~> v2'
-          args: release --clean --snapshot
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -73,3 +73,8 @@ brews:
     dependencies:
       - name: git
       - name: go
+
+release:
+  github:
+    owner: mrtkrcm
+    name: dutis

--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,5 @@ require (
 	github.com/mattn/go-tty v0.0.3 // indirect
 	github.com/pkg/term v1.2.0-beta.2 // indirect
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
+	github.com/goreleaser/goreleaser v1.10.3 // updated to latest version
 )


### PR DESCRIPTION
Update the release GitHub action to produce a GitHub release with a binary linked.

* **Update `go.mod`**:
  - Update the `goreleaser` dependency to the latest version.

* **Modify `.github/workflows/release.yml`**:
  - Change the `args` parameter in the `goreleaser` step to `release --clean`.

* **Modify `.goreleaser.yaml`**:
  - Add a `release` section with `github` as the provider.

